### PR TITLE
Keeping name pattern of handler functions 

### DIFF
--- a/src/commandHandlers/closeAll.ts
+++ b/src/commandHandlers/closeAll.ts
@@ -1,5 +1,5 @@
 import {QuitMenu} from '../QuitMenu'
 
-export function closeAll(){
+export function closeAllHandler(){
     QuitMenu.showFocusingCloseWindow()
 }

--- a/src/commandHandlers/index.ts
+++ b/src/commandHandlers/index.ts
@@ -1,3 +1,3 @@
 export {quitHandler as quitCommandHandler} from './quit'
-export {closeAll as closeAllCommandHandler} from './closeAll'
+export {closeAllHandler as closeAllCommandHandler} from './closeAll'
 export {closeCurrentHandler as closeCurrentCommandHandler} from './closeCurrent'


### PR DESCRIPTION
Because of inconsistent file names, the extension stopped working on Ubuntu. This PR only modifies the method `closeAll()` to `closeAllHandler()`, keeping the same pattern as other files. But the goal is recreate the package to republish to Marketplace, with the correct cases in file names. Tested with:
```
vsce package
code --uninstall-extension artdiniz.quitcontrol-vscode
code --install-extension quitcontrol-vscode-3.1.1.vsix
```
After a restart, the extension returned to work. Maybe the VSIX in VS Code Marketplace was wrongly packaged. I'm open to help if needed.