### PR TITLE
Clean output dir before packaging vsix file. Fix #12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -709,6 +709,15 @@
                 "path-parse": "^1.0.6"
             }
         },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,9 @@
         ]
     },
     "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
+        "vscode:prepublish": "npm run clean && npm run compile",
+        "clean": "rimraf ./out",
+        "compile": "tsc --outDir ./out -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run compile && node ./node_modules/vscode/bin/test",
@@ -59,6 +60,7 @@
     "devDependencies": {
         "@types/mocha": "^2.2.32",
         "@types/node": "^8.10.47",
+        "rimraf": "^2.6.3",
         "tslint": "^5.11.0",
         "typescript": "^2.9.2",
         "vscode": "^1.1.33"


### PR DESCRIPTION
As pointed by @thiagobraga in [this issue](https://github.com/artdiniz/quit-control-vscode/issues/12#issuecomment-489890296), vsix files where packaged with wrong file names.

TL;DR; 
Removing `out` dir before compiling forces `tsc` to recreate all compiled files with proper names.
____
This was happening because `tsc` tries not to recreate files if their names weren't changed. This verification isn't case sensitive, thus a previous change modifying a file name from `CloseAll.ts` to `closeAll.ts` wasn't changing the output file from `CloseAll.ts` to `closeAll.ts`. 