### PR TITLE
fix keybinding labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 All notable changes to the "Quit Control for VSCode" extension will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+
+## 3.2.1 - UNRELEASED
+#### Fixed
+- Keybinding labels were wrong on non empty window
+
 ## 3.2.0 - 2021-05-26
 ### Changed
 - When there are no windows left you can use `⌘Q` to quit vscode. From [issue #24](https://github.com/artdiniz/quit-control-vscode/issues/24)
 - Namespace of commands and contexts changed from `quitPlugin` to `quitControl`
-- Following [VSCode recommendation](https://code.visualstudio.com/api/references/activation-events#onStartupFinished) of activating extension after `onStartupFinished` and `onCommand:${commandName}`.
+- Following [VSCode recommendation](https://code.visualstudio.com/api/references/activation-events#onStartupFinished) of activating extension after `onStartupFinished` and `onCommand:${commandName}`
 
 ## 3.1.3 - 2019-05-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 
 ## 3.2.1 - UNRELEASED
-#### Fixed
+### Fixed
 - Keybinding labels were wrong on non empty window
 
 ## 3.2.0 - 2021-05-26

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "quitcontrol-vscode",
     "displayName": "Quit Control for VSCode",
     "description": "Stop mistyping keyboard shortctus that close/quit VSCode unintentionally",
-    "version": "3.2.0",
+    "version": "3.2.0-rc3",
     "publisher": "artdiniz",
     "author": {
         "name": "Artur Diniz Adam",
@@ -25,8 +25,9 @@
     "activationEvents": [
         "onStartupFinished",
         "onCommand:quitControl.keybindings.quit",
+        "onCommand:quitControl.keybindings.quitEmptyWindow",
         "onCommand:quitControl.keybindings.closeWindow",
-        "onCommand:quitControl.keybindings.closeEditor"
+        "onCommand:quitControl.keybindings.closeEmptyWindow"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -39,13 +40,20 @@
                 "when": "quitControl.isActive"
             },
             {
+                "command": "quitControl.keybindings.quitEmptyWindow",
+                "title": "Quit VSCode",
+                "key": "ctrl+Q",
+                "mac": "cmd+Q",
+                "when": "!editorIsOpen && !multipleEditorGroups"
+            },
+            {
                 "command": "quitControl.keybindings.closeWindow",
                 "title": "Close Window",
                 "key": "ctrl+shift+W",
                 "mac": "cmd+shift+W"
             },
             {
-                "command": "quitControl.keybindings.closeEditor",
+                "command": "quitControl.keybindings.closeEmptyWindow",
                 "title": "Close Editor",
                 "key": "ctrl+W",
                 "mac": "cmd+W",

--- a/src/QuitMenu.ts
+++ b/src/QuitMenu.ts
@@ -8,7 +8,19 @@ const quitFocusedOptions = [
     ,QuitMenuOptions.Cancel
 ]
 
-const closedWindowFocusedOptions = [
+const quitEmptyWindowFocusedOptions = [
+    asFocusedOption(QuitMenuOptions.Quit)
+    ,QuitMenuOptions.CloseEmptyWindow
+    ,QuitMenuOptions.Cancel
+]
+
+const closeEmptyWindowFocusedOptions = [
+    asFocusedOption(QuitMenuOptions.CloseEmptyWindow)
+    ,QuitMenuOptions.Quit
+    ,QuitMenuOptions.Cancel
+]
+
+const closeWindowFocusedOptions = [
     asFocusedOption(QuitMenuOptions.CloseWindow)
     ,QuitMenuOptions.Quit
     ,QuitMenuOptions.Cancel
@@ -23,6 +35,8 @@ const show = (options: IQuitControlQuickPickItem[]) =>
         })
 
 export const QuitMenu = {
-    showFocusingQuit: () => show(quitFocusedOptions)
-    ,showFocusingCloseWindow: () => show(closedWindowFocusedOptions)
+    showFocusingQuit: () => show(quitFocusedOptions),
+    showFocusingQuitEmptyWindow: () => show(quitEmptyWindowFocusedOptions)
+    ,showFocusingCloseWindow: () => show(closeWindowFocusedOptions)
+    ,showFocusingCloseEmptyWindow: () => show(closeEmptyWindowFocusedOptions)
 }

--- a/src/QuitMenuOptions.ts
+++ b/src/QuitMenuOptions.ts
@@ -3,7 +3,7 @@ import * as os from 'os'
 
 const isMacOS = (os.platform() === "darwin" )
 
-type QuickPitckItems = 'Quit' | 'CloseWindow' | 'Cancel'
+type QuickPitckItems = 'Quit' | 'CloseEmptyWindow' | 'CloseWindow' | 'Cancel'
 export interface IQuitControlQuickPickItem extends QuickPickItem {
     label: string
     description: string
@@ -21,9 +21,14 @@ export const QuitMenuOptions: {[key in QuickPitckItems]: IQuitControlQuickPickIt
         ,description: isMacOS ? '⌘Q' : '^Q'
         ,command: 'workbench.action.quit'
     }
-    ,CloseWindow: {
+    ,CloseEmptyWindow: {
         label: 'Close Window'
         ,description: isMacOS? '⇧⌘W, ⌘W' : '⇧^W, ^W '
+        ,command: 'workbench.action.closeWindow'
+    }
+    ,CloseWindow: {
+        label: 'Close Window'
+        ,description: isMacOS? '⇧⌘W' : '⇧^W'
         ,command: 'workbench.action.closeWindow'
     }
     ,Cancel: {

--- a/src/QuitMenuOptions.ts
+++ b/src/QuitMenuOptions.ts
@@ -23,7 +23,7 @@ export const QuitMenuOptions: {[key in QuickPitckItems]: IQuitControlQuickPickIt
     }
     ,CloseEmptyWindow: {
         label: 'Close Window'
-        ,description: isMacOS? '⇧⌘W, ⌘W' : '⇧^W, ^W '
+        ,description: isMacOS? '⇧⌘W, ⌘W' : '⇧^W, ^W'
         ,command: 'workbench.action.closeWindow'
     }
     ,CloseWindow: {

--- a/src/commandHandlers/closeCurrent.ts
+++ b/src/commandHandlers/closeCurrent.ts
@@ -1,5 +1,0 @@
-import {QuitMenu} from '../QuitMenu'
-
-export function closeCurrentHandler() {
-    QuitMenu.showFocusingCloseWindow()
-}

--- a/src/commandHandlers/closeEmptyWindow.ts
+++ b/src/commandHandlers/closeEmptyWindow.ts
@@ -1,0 +1,5 @@
+import {QuitMenu} from '../QuitMenu'
+
+export function closeEmptyWindowHandler() {
+    QuitMenu.showFocusingCloseEmptyWindow()
+}

--- a/src/commandHandlers/closeWindow.ts
+++ b/src/commandHandlers/closeWindow.ts
@@ -1,5 +1,5 @@
 import {QuitMenu} from '../QuitMenu'
 
-export function closeAllHandler(){
+export function closeWindowHandler(){
     QuitMenu.showFocusingCloseWindow()
 }

--- a/src/commandHandlers/index.ts
+++ b/src/commandHandlers/index.ts
@@ -1,3 +1,3 @@
-export {quitHandler as quitCommandHandler} from './quit'
-export {closeAllHandler as closeAllCommandHandler} from './closeAll'
-export {closeCurrentHandler as closeCurrentCommandHandler} from './closeCurrent'
+export {quitHandler as quitCommandHandler, quitEmptyWindow as quitCommandEmptyWindowHandler} from './quit'
+export {closeWindowHandler as closeWindowCommandHandler} from './closeWindow'
+export {closeEmptyWindowHandler as closeEmptyWindowCommandHandler} from './closeEmptyWindow'

--- a/src/commandHandlers/quit.ts
+++ b/src/commandHandlers/quit.ts
@@ -1,5 +1,11 @@
 import {QuitMenu} from '../QuitMenu'
 
 export function quitHandler() {
+    console.log('QUIT')
     QuitMenu.showFocusingQuit()
+}
+
+export function quitEmptyWindow() {
+    console.log('QUIT EMPTY')
+    QuitMenu.showFocusingQuitEmptyWindow()
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import {quitCommandHandler, closeAllCommandHandler, closeCurrentCommandHandler} from './commandHandlers'
+import {quitCommandHandler, quitCommandEmptyWindowHandler, closeWindowCommandHandler, closeEmptyWindowCommandHandler} from './commandHandlers'
 
 export const activate = function (context: vscode.ExtensionContext) {
     const quitCommand = vscode.commands.registerCommand(
@@ -7,18 +7,24 @@ export const activate = function (context: vscode.ExtensionContext) {
         , quitCommandHandler
     )
 
+    const quitCommandEmptyWindow = vscode.commands.registerCommand(
+        'quitControl.keybindings.quitEmptyWindow'
+        , quitCommandEmptyWindowHandler
+    )
+
     const closeAllCommand = vscode.commands.registerCommand(
         'quitControl.keybindings.closeWindow'
-        , closeAllCommandHandler
+        , closeWindowCommandHandler
     )
     const closeCurrentCommand = vscode.commands.registerCommand(
-        'quitControl.keybindings.closeEditor'
-        , closeCurrentCommandHandler
+        'quitControl.keybindings.closeEmptyWindow'
+        , closeEmptyWindowCommandHandler
     )
 
     context.subscriptions.push(closeAllCommand)
     context.subscriptions.push(closeCurrentCommand)
     context.subscriptions.push(quitCommand)
+    context.subscriptions.push(quitCommandEmptyWindow)
 
     vscode.commands.executeCommand('setContext', 'quitControl.isActive', true);
 }


### PR DESCRIPTION
When there are tabs open, `⌘W` doesn't close the window, so it should not show up as a keybinding in the menu.

### Before:
![image](https://user-images.githubusercontent.com/1895150/119603325-56f37400-bdc3-11eb-9249-be547da60bfe.png)

### After:
![image](https://user-images.githubusercontent.com/1895150/119603684-0892a500-bdc4-11eb-844b-21c1c4730ae5.png)
