### PR TITLE
support extensionKind ui or workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "engines": {
         "vscode": "^1.5.0"
     },
+    "extensionKind": [
+        "ui",
+        "workspace"
+    ],
     "categories": [
         "Keymaps",
         "Other"


### PR DESCRIPTION
### What

Indicate to VSCode that the extension can run in `ui` mode or in `workspace` mode.

### Why

When using VSCode with remote containers support VSCode can run extensions locally where the UI is being displayed or remotely where the files live. Many extension can run in either location, although some extension can only run on the ui side and some can only run on the workspace side.

When an extension doesn't indicate where it can be run it always runs at the workspace side.

The multi-command extension can run either on the UI or on the workspace and I think it should really be up to the user to choose, by default running in the ui.

The biggest win is that for developers who join a dev container the extension will continue to run locally and the extension will catch them pressing the quit shortcuts. Without this change when a developer joins a dev container the extension disables and they lose that quit protection.